### PR TITLE
Conditionally make the ./dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist/* db/development.sqlite && npm run prepcerts",
     "test": "jest",
     "start": "node ./server/index.js",
-    "prepcerts": "./run gen-certs && rm -rf dist/*.pem && cp private/*.pem dist/"
+    "prepcerts": "./run gen-certs && rm -rf dist/*.pem && mkdir -p dist && cp private/*.pem dist/"
   },
   "devDependencies": {
     "@types/react": "^15.0.35",


### PR DESCRIPTION
Because `./dist` directory is empty, it's not included in Git when a new user clones the repository. This makes `cp` very upset. So, we'll conditionally make it!